### PR TITLE
[COMCTL32] ToolTips: Don't set text on default LPSTR_TEXTCALLBACK (#6…

### DIFF
--- a/dll/win32/comctl32/tooltips.c
+++ b/dll/win32/comctl32/tooltips.c
@@ -417,6 +417,7 @@ static void TOOLTIPS_GetDispInfoA(const TOOLTIPS_INFO *infoPtr, TTTOOL_INFO *too
         buffer[0] = '\0';
     }
 
+#ifndef __REACTOS_
     /* no text available - try calling parent instead as per native */
     /* FIXME: Unsure if SETITEM should save the value or not        */
     if (buffer[0] == 0x00) {
@@ -431,6 +432,7 @@ static void TOOLTIPS_GetDispInfoA(const TOOLTIPS_INFO *infoPtr, TTTOOL_INFO *too
             Str_GetPtrAtoW(ttnmdi.lpszText, buffer, INFOTIPSIZE);
         }
     }
+#endif
 }
 
 static void TOOLTIPS_GetDispInfoW(const TOOLTIPS_INFO *infoPtr, TTTOOL_INFO *toolPtr, WCHAR *buffer)
@@ -473,6 +475,7 @@ static void TOOLTIPS_GetDispInfoW(const TOOLTIPS_INFO *infoPtr, TTTOOL_INFO *too
         buffer[0] = '\0';
     }
 
+#ifndef __REACTOS__
     /* no text available - try calling parent instead as per native */
     /* FIXME: Unsure if SETITEM should save the value or not        */
     if (buffer[0] == 0x00) {
@@ -487,6 +490,7 @@ static void TOOLTIPS_GetDispInfoW(const TOOLTIPS_INFO *infoPtr, TTTOOL_INFO *too
             Str_GetPtrW(ttnmdi.lpszText, buffer, INFOTIPSIZE);
         }
     }
+#endif
 
 }
 


### PR DESCRIPTION
…412)

Based on KRosUser's tooltip_fix.patch.
JIRA issue: CORE-19309
Don't set text on default processing
of LPSTR_TEXTCALLBACK.

## Purpose

_Do a quick recap of your work here._

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- 
- 

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] 
- [ ] 
